### PR TITLE
genslaxiso: enable adding user rootcopy dir

### DIFF
--- a/Slax/debian9/rootcopy/usr/bin/genslaxiso
+++ b/Slax/debian9/rootcopy/usr/bin/genslaxiso
@@ -4,9 +4,17 @@ CWD=$(pwd)
 SOURCE=/run/initramfs/memory
 TEMP=/tmp/slaxiso.$$
 REGEX='^$'
+ROOTCOPY=''
+RCPYEX='^$'
 
 if [ "$1" = "-e" ]; then
    REGEX="$2"
+   shift
+   shift
+fi
+
+if [ "$1" = "-d" ]; then
+   ROOTCOPY="$2"
    shift
    shift
 fi
@@ -19,7 +27,7 @@ if [ "$TARGET" = "" ]; then
    echo "Regular expression is used to exclude any existing path or file with -e regex"
    echo ""
    echo "Usage:"
-   echo "        $0 [[ -e regex ]] target.iso [[module.sb]] [[module.sb]] ..."
+   echo "        $0 [[ -e regex ]] [[ -d dir ]] target.iso [[module.sb]] [[module.sb]] ..."
    echo ""
    echo "Examples:"
    echo "        # to create Slax iso without chromium.sb module:"
@@ -27,6 +35,9 @@ if [ "$TARGET" = "" ]; then
    echo ""
    echo "        # to create Slax text-mode core only:"
    echo "        $0 -e 'firmware|xorg|desktop|apps|chromium' slax_textmode.iso"
+   echo ""
+   echo "        # to create Slax with user rootcopy directory (from /tmp/my-rootcopy/*):"
+   echo "        $0 -d '/tmp/my-rootcopy' slax_with_rootcopy.iso"
    exit 1
 fi
 
@@ -47,10 +58,24 @@ if [ "$SLAX" = "" ]; then
    exit 2
 fi
 
+# add the rootcopy folder
+if [ ! -z "$ROOTCOPY" -a -d "$ROOTCOPY" ]; then
+   echo "ROOTCOPY in use: $ROOTCOPY"
+   RCPYEX='^rootcopy/'
+   ROOTCOPY="/slax/rootcopy=$ROOTCOPY"
+elif [ ! -z "$ROOTCOPY" ]; then
+   echo "ROOTCOPY error: disabling it!"
+   RCPYEX='^rootcopy/'
+   ROOTCOPY=''
+else
+   echo "ROOTCOPY in use: from current image"
+   ROOTCOPY=''
+fi
+
 GRAFT=\
 $(
   cd "$SLAX"
-  find . -type f | sed -r "s:^[.]/::" | egrep -v "^boot/isolinux.(bin|boot)$" | egrep -v "^changes/" | egrep -v "$REGEX" | while read LINE; do
+  find . -type f | sed -r "s:^[.]/::" | egrep -v "^boot/isolinux.(bin|boot)$" | egrep -v "^changes/" | egrep -v "$REGEX" | egrep -v "$RCPYEX" | while read LINE; do
      echo "slax/$LINE=$SLAX/$LINE"
   done
 )


### PR DESCRIPTION
Add support to add a custom user rootcopy directory to the resulting ISO image. It's preferable that the user first copies the current rootcpy to this user target directory and then add his own files to it, before using the genslaxiso script.