### PR TITLE
Add user-preinit support

### DIFF
--- a/initramfs/init
+++ b/initramfs/init
@@ -54,6 +54,9 @@ copy_rootcopy_content "$DATA" "$UNION"
 # create fstab
 fstab_create "$UNION" "$DATAMNT"
                                                                                                                                                       debug_shell
+# run user custom preinit
+user_preinit "$DATA" "$UNION"
+
 header "Live Kit done, starting $LIVEKITNAME"
 change_root "$UNION"
 

--- a/livekitlib
+++ b/livekitlib
@@ -700,6 +700,26 @@ copy_rootcopy_content()
 }
 
 
+# Run user custom preinit script if it exists
+# $1 = data directory
+# $2 = union directory
+user_preinit()
+{
+   debug_log "user_preinit" "$*"
+
+   local SRC
+
+   SRC="$1/rootcopy/run/preinit.sh"
+
+   if [ "$(ls -1 "$SRC" 2>/dev/null)" != "" ]; then
+      echo_green_star
+      echo "Executing user custom preinit..."
+      debug_log "Executing user custom preinit [$SRC]"
+      . "$SRC" "$2"
+   fi
+}
+
+
 # Copy data to RAM if requested
 # $1 = live data directory
 # $2 = changes directory


### PR DESCRIPTION
In some environments it will be interesting that the user can execute some script at the LiveKit level.

This patch enables the option to execute the script "/rootcopy/run/preinit.sh" just after ending the LiveKit setup process and before calling to the change_root. With this strategy the user can't break something releveant in the LiveKit but has the option to include some useful stuff before starting the regular boot with access to the entire filesystem. This could be used to test some develop to the LiveKit or to adapt the environment to custom requirements.
  